### PR TITLE
OpenCV is missing from a couple of the nodes' CMakelists files

### DIFF
--- a/ndt_costmap/CMakeLists.txt
+++ b/ndt_costmap/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 #include_directories(${LIBXML2_INCLUDE_DIR})
 #ADD_DEFINITIONS(-DLINUX_OS)
 find_package(OpenGL REQUIRED)
+find_package(OpenCV REQUIRED)
 #find_package(GLU REQUIRED)
 #find_package(GLUT REQUIRED)
 #find_package(JPEG REQUIRED)
@@ -136,6 +137,7 @@ add_executable(slice_map src/slice_map.cpp)
 target_link_libraries(ndt_costmap
   ${catkin_LIBRARIES} ${Boost_LIBRARIES}
   ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES}
+  ${catkin_LIBRARIES} ${OpenCV_LIBS}
 )
 
 target_link_libraries(2d_occ_map

--- a/ndt_offline/CMakeLists.txt
+++ b/ndt_offline/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories(${catkin_INCLUDE_DIRS})
 ADD_DEFINITIONS(-DLINUX_OS)
 #find_package(ndt_visualisation)
 find_package(OpenGL REQUIRED)
+find_package(OpenCV REQUIRED)
 find_package(GLU REQUIRED)
 find_package(GLUT REQUIRED)
 find_package(JPEG REQUIRED)
@@ -71,7 +72,7 @@ target_link_libraries(fuser3d_offline ${LIBXML2_LIBRARIES} ${GLUT_LIBRARIES} ${J
 
 
 add_executable(bag_converter src/bag_converter.cpp)
-target_link_libraries(bag_converter ${LIBXML2_LIBRARIES} ${GLUT_LIBRARIES} ${JPEG_LIBRARIES} ${OPENGL_LIBRARIES} ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${Eigen_INCLUDE_DIRS})
+target_link_libraries(bag_converter ${LIBXML2_LIBRARIES} ${GLUT_LIBRARIES} ${JPEG_LIBRARIES} ${OPENGL_LIBRARIES} ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${Eigen_INCLUDE_DIRS} ${catkin_LIBRARIES} ${OpenCV_LIBS})
 
 add_executable(bag_file_view src/bag_file_view.cpp)
 target_link_libraries(bag_file_view ${LIBXML2_LIBRARIES} ${GLUT_LIBRARIES} ${JPEG_LIBRARIES} ${OPENGL_LIBRARIES} ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${Eigen_INCLUDE_DIRS})


### PR DESCRIPTION
Both ndt_offline and ndt_costmap would not compile on Ubuntu 16.04 and complained of unreferenced CV libraries. It turned out the CMakelists files for those nodes were missing the OpenCV library references.