### PR TITLE
Fixed the initialization of the coordinates of the center of a point cloud in NDTMap

### DIFF
--- a/ndt_map/include/ndt_map/ndt_map.h
+++ b/ndt_map/include/ndt_map/ndt_map.h
@@ -169,6 +169,9 @@ public:
     map_sizex = sizex;
     map_sizey = sizey;
     map_sizez = sizez;
+    centerx = cenx;
+    centery = ceny;
+    centerz = cenz;
     is3D=true;
     LazyGrid *lz = dynamic_cast<LazyGrid*>(index_);
     if(lz == NULL)
@@ -198,6 +201,9 @@ public:
     map_sizex = sizex;
     map_sizey = sizey;
     map_sizez = sizez;
+    centerx = cenx;
+    centery = ceny;
+    centerz = cenz;
     is3D=true;
     LazyGrid *lz = dynamic_cast<LazyGrid*>(index_);
     if(lz == NULL)


### PR DESCRIPTION
The member variables `centerx`, `centery`, and `centerz` are not initialized correctly when using the NDTMap constructor `NDTMap(SpatialIndex *idx, float cenx, float ceny, float cenz, float sizex, float sizey, float sizez, bool dealloc = false)`. For instance, in a code like this:

`perception_oru::LazyGrid * lz = new perception_oru::LazyGrid(0.1);`
`perception_oru::NDTMap map(lz,0,0,0,10,10,10);`

The members `centerx`, `centery`, and `centerz` in map are uninitialized, even though the center in the LazyGrid was initialized correctly. This means that when calling `addPointCloud`, the very first call defaults to loadPointCloud (ndt_map.cpp, line 305), which clones the index (ndt_map.cpp, line 33), forgetting the values of the center in the new index. In this case (`guess_size_` is false), the values in the new LazyGrid are pulled from the NDTMap itself (ndt_map.cpp, line 144), but those values are undefined:
`index_->setCenter(centerx,centery,centerz);`
From now on, all the functions using those coordinates in the index are corrupted (in my case, the center was initialized to a nan, meaning in particular that any call to getIndexForPoint would fail, thus it was impossible to add points).
The simple fix is I think to just initialize  `centerx`, `centery`, and `centerz` in the constructor. 

I have added the same initialization in the `NDTMap::initialize` function since I can see the same kind of bug happening, however in this case, I am not sure if this is intentional (since as far as I can tell, `initialize` for NDTMap is not used in the NDTMap package), but I suspect that since `cenx`, `ceny` and `cenz` are provided as arguments, it is expected to update those values in the NDTMap class.