### PR TITLE
Memory leak in NDTMap constructor

### DIFF
--- a/ndt_map/src/lazy_grid.cpp
+++ b/ndt_map/src/lazy_grid.cpp
@@ -148,7 +148,7 @@ void LazyGrid::initializeAll()
 
 void LazyGrid::initialize()
 {
-
+	if(initialized) return;
     dataArray = new NDTCell***[sizeX];
     for(int i=0; i<sizeX; i++)
     {


### PR DESCRIPTION
There is a memory leak in one of the constructors of NDTMap:
`NDTMap(SpatialIndex *idx, float cenx, float ceny, float cenz, float sizex, float sizey, float sizez, bool dealloc = false)`
The same is true for the member initialization function :
`void initialize(double cenx, double ceny, double cenz, double sizex, double sizey, double sizez)`
The problem is that the initialize function of the index LazyGrid is called twice:
-once after the call to `index_->setCenter` and `index_->setCenter` (if my understanding is right, when those two functions have been called, the initialization occurs automatically, see line 83 and 96 of lazy_grid.cpp).
-once manually (lines 182/215 of ndt_map.h)
This results in a memory leak, since the pointer dataArray is overwritten without deletion.

The proposed solution is to prevent initialize to be called if the LazyGrid was already initialized, but this is not ideal if the LazyGrid actually needs to be initalized again (with a different size for instance).